### PR TITLE
Deprecated package

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+High (equivalent to GenoM) Level Remote Procedure Calls (RPC) example to communicate to 3DROV simulator and Modules (thermal/env.etc...) using rock/orogen components — Edit
+
+This package requieres rpc_vdal_3drov as part of 3DROV property of the Trasys company (http://www.trasys.be)

--- a/manifest.xml
+++ b/manifest.xml
@@ -13,5 +13,5 @@
   <depend package="dummy-dependency-n" />
   -->
   <depend package="base/types" />
-  <deprivated>1</depricated>
+  <deprecated>1</deprecated>
 </package>

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,5 +1,8 @@
 <package>
-  <description brief="HighLevel RPC connexion for 3DROV">
+ <description brief="HighLevel RPC connexion for 3DROV">
+    High (equivalent to GenoM) Level Remote Procedure Calls (RPC) example
+    to communicate to 3DROV simulator and Modules (thermal/env.etc...)
+    using rock/orogen components.
   </description>
   <author>Javier Hidalgo Carrio/javier.hidalgo-carrio@dfki.de</author>
   <license>LGPLv2 or later</license>

--- a/manifest.xml
+++ b/manifest.xml
@@ -1,9 +1,8 @@
 <package>
   <description brief="HighLevel RPC connexion for 3DROV">
-  
   </description>
-  <author>/</author>
-  <license></license>
+  <author>Javier Hidalgo Carrio/javier.hidalgo-carrio@dfki.de</author>
+  <license>LGPLv2 or later</license>
   <url>http://</url>
   <logo>http://</logo>
   <!--
@@ -14,4 +13,5 @@
   <depend package="dummy-dependency-n" />
   -->
   <depend package="base/types" />
+  <deprivated>1</depricated>
 </package>


### PR DESCRIPTION
Following discussion in rock-dev emailing list. I guess the correct manifest tag is <deprecated>
In addition to it and in order to be rock compliance the name of the repo in rock-simulation should be "simulation-orogen-highlevel_rpc_3drov"

A clone of https://github.com/jhidalgocarrio/simulation-orogen-lowlevel_rpc_3drov in https://github.com/rock-simulation should also be necessary to be correct. When done I will fork the new one from rock-simulation instead of having it in my account.
